### PR TITLE
remove componentWillReceiveProps from Loader

### DIFF
--- a/packages/react-cosmos-loader/src/components/Loader/index.js
+++ b/packages/react-cosmos-loader/src/components/Loader/index.js
@@ -1,55 +1,39 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { func, object, arrayOf } from 'prop-types';
 import createLinkedList from '@skidding/linked-list';
 import { createModuleType } from '../../utils/module-type';
 import { PropsProxy } from '../PropsProxy';
 
-export class Loader extends Component {
-  static propTypes = {
-    fixture: createModuleType(object).isRequired,
-    proxies: arrayOf(createModuleType(func)),
-    onComponentRef: func
-  };
+/**
+ * Loader for rendering React components in isolation.
+ *
+ * Renders components using fixtures and Proxy middleware. Initialized via
+ * props.
+ */
+const Loader = ({ fixture, proxies, onComponentRef, onFixtureUpdate }) => {
+  const firstProxy = createLinkedList([...proxies, PropsProxy]);
 
-  static defaultProps = {
-    proxies: []
-  };
+  return (
+    <firstProxy.value
+      nextProxy={firstProxy.next()}
+      fixture={fixture}
+      onComponentRef={onComponentRef}
+      onFixtureUpdate={onFixtureUpdate}
+    />
+  );
+};
 
-  /**
-   * Loader for rendering React components in isolation.
-   *
-   * Renders components using fixtures and Proxy middleware. Initialized via
-   * props.
-   */
-  constructor(props) {
-    super(props);
+Loader.propTypes = {
+  fixture: createModuleType(object).isRequired,
+  proxies: arrayOf(createModuleType(func)),
+  onFixtureUpdate: func,
+  onComponentRef: func
+};
 
-    this.firstProxy = createProxyLinkedList(props.proxies);
-  }
+Loader.defaultProps = {
+  proxies: [],
+  onFixtureUpdate: () => {},
+  onComponentRef: () => {}
+};
 
-  componentWillReceiveProps({ proxies }) {
-    if (proxies !== this.props.proxies) {
-      this.firstProxy = createProxyLinkedList(proxies);
-    }
-  }
-
-  render() {
-    const { firstProxy } = this;
-    const { fixture, onComponentRef, onFixtureUpdate } = this.props;
-
-    return (
-      <firstProxy.value
-        nextProxy={firstProxy.next()}
-        fixture={fixture}
-        onComponentRef={onComponentRef || noope}
-        onFixtureUpdate={onFixtureUpdate || noope}
-      />
-    );
-  }
-}
-
-function createProxyLinkedList(userProxies) {
-  return createLinkedList([...userProxies, PropsProxy]);
-}
-
-function noope() {}
+export { Loader };


### PR DESCRIPTION
As discussed in react-cosmos/react-cosmos/issues/984 I generate the linked list of proxies on the fly. The component does not have any instance or state variables any more, so I turned it into a functional component as well.

Any feedback and is there anything except for the tests I need to run?

**Changes**
Fix for react-cosmos/react-cosmos#984
- Use dynamic linked proxy list in Loader component
- Turn Loader into function component