### PR TITLE
Parse form spaces on routed query string

### DIFF
--- a/packages/react-querystring-router/src/__tests__/uri.js
+++ b/packages/react-querystring-router/src/__tests__/uri.js
@@ -36,3 +36,15 @@ test('generates location with query string from params', () => {
 
   expect(stringifyParams(params)).toBe('?name=Jack&info=%7B%22age%22%3A25%7D');
 });
+
+test('parses stringified and form encoded params from location', () => {
+  const uriLocation =
+    'mypage.com?formValue=first+middle+last&encodedValue=first%20middle%20last&plusValue=first%2Bmiddle%2Blast';
+  const params = parseLocation(uriLocation);
+
+  expect(params).toEqual({
+    formValue: 'first middle last',
+    encodedValue: 'first middle last',
+    plusValue: 'first+middle+last'
+  });
+});

--- a/packages/react-querystring-router/src/uri.js
+++ b/packages/react-querystring-router/src/uri.js
@@ -18,7 +18,7 @@ export function parseLocation(location) {
   pairs.forEach(pair => {
     parts = pair.split('=');
     [key] = parts;
-    value = decodeURIComponent(parts[1]);
+    value = decodeURIComponent(parts[1].replace(/\+/g, '%20'));
 
     try {
       value = JSON.parse(value);


### PR DESCRIPTION
Hi guys,

I'm using your querystring router for a project, and I found your router doesn't take care about spaces in submitted form.
Whan a form is submitted, it encodes spaces as "+" char.
There is no way of changing this behavior.

Now, just before parsing the value, I replace all "+" chars by "%20" string.